### PR TITLE
Improve space-elevator-travel-failed-too-far

### DIFF
--- a/space-exploration/space-exploration_0.6.94_DE_strings.cfg
+++ b/space-exploration/space-exploration_0.6.94_DE_strings.cfg
@@ -910,7 +910,7 @@ space-elevator-placement-invalid-opposite-alert=Der Weltraumlift kann nicht auf 
 space-elevator-broken=Das Halteseil eines Weltraumlifts ist gerissen. __1__
 space-elevator-view-opposite=[img=item/se-space-elevator] Anderes Ende anzeigen
 space-elevator-travel=Reise
-space-elevator-travel-failed-too-far=Du musst neben dem Weltraumlift stehen, um mit ihm zu reisen. Du warst __1__ Einheiten entfernt, aber musst näher als __2__ Einheiten sein.
+space-elevator-travel-failed-too-far=Du musst neben dem Weltraumlift stehen, um mit ihm zu reisen. Du warst __1__ Einheiten entfernt, darfst aber maximal __2__ Einheiten entfernt sein.
 space-elevator-travel-failed-remote-view=Du kannst nur mit dem Weltraumlift reisen, wenn du den Navigationsatelliten nicht anschaust.
 space-elevator-travel-failed-built=Der Lift ist nicht vollständig gebaut.
 space-elevator-travel-failed-parts=Der Lift hat nicht genug Teile.

--- a/space-exploration/space-exploration_0.6.94_DE_strings.cfg
+++ b/space-exploration/space-exploration_0.6.94_DE_strings.cfg
@@ -910,7 +910,7 @@ space-elevator-placement-invalid-opposite-alert=Der Weltraumlift kann nicht auf 
 space-elevator-broken=Das Halteseil eines Weltraumlifts ist gerissen. __1__
 space-elevator-view-opposite=[img=item/se-space-elevator] Anderes Ende anzeigen
 space-elevator-travel=Reise
-space-elevator-travel-failed-too-far=Du musst neben dem Weltraumlift stehen, um mit ihm zu reisen. Du warst __1__ Einheiten entfernt, aber musst innerhalb von__2__ Einheiten sein.
+space-elevator-travel-failed-too-far=Du musst neben dem Weltraumlift stehen, um mit ihm zu reisen. Du warst __1__ Einheiten entfernt, aber musst näher als __2__ Einheiten sein.
 space-elevator-travel-failed-remote-view=Du kannst nur mit dem Weltraumlift reisen, wenn du den Navigationsatelliten nicht anschaust.
 space-elevator-travel-failed-built=Der Lift ist nicht vollständig gebaut.
 space-elevator-travel-failed-parts=Der Lift hat nicht genug Teile.


### PR DESCRIPTION
2 changes:

- `musst innerhalb von x sein` sounds kind of stiff
- `von__2__` missing space

-----

Do you prefer German PR descriptions over English ones?