### PR TITLE
update space-elevator-travel-failed-remote-view

### DIFF
--- a/space-exploration/space-exploration_0.6.94_DE_strings.cfg
+++ b/space-exploration/space-exploration_0.6.94_DE_strings.cfg
@@ -911,7 +911,7 @@ space-elevator-broken=Das Halteseil eines Weltraumlifts ist gerissen. __1__
 space-elevator-view-opposite=[img=item/se-space-elevator] Anderes Ende anzeigen
 space-elevator-travel=Reise
 space-elevator-travel-failed-too-far=Du musst neben dem Weltraumlift stehen, um mit ihm zu reisen. Du warst __1__ Einheiten entfernt, darfst aber maximal __2__ Einheiten entfernt sein.
-space-elevator-travel-failed-remote-view=Du kannst nur mit dem Weltraumlift reisen, wenn du den Navigationsatelliten nicht anschaust.
+space-elevator-travel-failed-remote-view=Du kannst nicht mit dem Weltraumlift reisen, wenn du in der Navigationssatelliten-Ansicht bist.
 space-elevator-travel-failed-built=Der Lift ist nicht vollständig gebaut.
 space-elevator-travel-failed-parts=Der Lift hat nicht genug Teile.
 space-elevator-travel-failed-energy=Der Lift hat nicht genug Energie.


### PR DESCRIPTION
Ich finde die Verneinung am Ende sprachlich nicht so geläufig, daher habe ich den Satz entsprechend umgebaut.
Außerdem `Navigationsatelliten` -> `Navigationssatelliten`